### PR TITLE
Cotización + Ficha Técnica: reporte que adjunta fichas SEIQ

### DIFF
--- a/cristal_ficha_tecnica/__init__.py
+++ b/cristal_ficha_tecnica/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/cristal_ficha_tecnica/__manifest__.py
+++ b/cristal_ficha_tecnica/__manifest__.py
@@ -1,0 +1,32 @@
+{
+    "name": "Cristal - Cotización con Ficha Técnica",
+    "version": "18.0.1.0.0",
+    "summary": "Reporte de cotización/pedido que adjunta las fichas técnicas "
+    "de los productos SEIQ incluidos.",
+    "description": """
+Agrega un segundo reporte en las cotizaciones / pedidos de venta:
+"Cotización + Ficha Técnica".
+
+Genera exactamente el mismo PDF que el presupuesto estándar y, a continuación,
+adjunta la ficha técnica (documento PDF cargado en el producto) de cada producto
+que la tenga cargada. Las fichas se toman de los adjuntos del producto cuyo
+nombre contiene "ficha" (p. ej. "Ficha tecnica SEIQ - STRONG"), soportando tanto
+adjuntos binarios como enlaces URL (se descargan al vuelo).
+
+El reporte estándar de presupuesto no se modifica: este es un reporte adicional
+disponible en el menú Imprimir de la orden de venta.
+""",
+    "author": "Química Cristal",
+    "website": "https://github.com/Polaco45/QuimicaCristal",
+    "license": "LGPL-3",
+    "category": "Sales",
+    "depends": ["sale"],
+    "data": [
+        "report/sale_report_ficha.xml",
+    ],
+    "installable": True,
+    "application": False,
+    # Sus dependencias ('sale') ya están instaladas en el build de Odoo.sh,
+    # por lo que se instala automáticamente sin pasar por Apps.
+    "auto_install": True,
+}

--- a/cristal_ficha_tecnica/models/__init__.py
+++ b/cristal_ficha_tecnica/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_report

--- a/cristal_ficha_tecnica/models/ir_actions_report.py
+++ b/cristal_ficha_tecnica/models/ir_actions_report.py
@@ -1,0 +1,158 @@
+import base64
+import logging
+
+import requests
+
+from odoo import models
+from odoo.tools.pdf import merge_pdf
+
+_logger = logging.getLogger(__name__)
+
+# report_name del reporte "Cotización + Ficha Técnica" definido en
+# report/sale_report_ficha.xml. Solo ese reporte dispara el adjuntado de fichas.
+FICHA_REPORT_NAME = "cristal_ficha_tecnica.report_saleorder_ficha"
+
+# Tiempo máximo para descargar cada ficha técnica alojada por URL.
+_FETCH_TIMEOUT = 25
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
+        """Renderiza la cotización estándar y le adjunta, debajo, las fichas
+        técnicas (PDF) de los productos incluidos en la orden.
+
+        Solo actúa sobre el reporte ``FICHA_REPORT_NAME``; el resto de los
+        reportes PDF se comportan igual que siempre. Ante cualquier problema
+        al obtener o mergear las fichas, devuelve la cotización sola para no
+        romper la impresión.
+        """
+        pdf_content, report_type = super()._render_qweb_pdf(
+            report_ref, res_ids=res_ids, data=data
+        )
+
+        report = self._get_report(report_ref)
+        if not report or report.report_name != FICHA_REPORT_NAME or not res_ids:
+            return pdf_content, report_type
+
+        try:
+            ficha_pdfs = self._collect_seiq_datasheets(res_ids)
+        except Exception:  # noqa: BLE001 - nunca romper la impresión
+            _logger.exception(
+                "cristal_ficha_tecnica: fallo al recolectar fichas técnicas; "
+                "se imprime la cotización sin fichas."
+            )
+            return pdf_content, report_type
+
+        if not ficha_pdfs:
+            return pdf_content, report_type
+
+        try:
+            merged = merge_pdf([pdf_content] + ficha_pdfs)
+        except Exception:  # noqa: BLE001
+            _logger.exception(
+                "cristal_ficha_tecnica: fallo al mergear las fichas técnicas; "
+                "se imprime la cotización sin fichas."
+            )
+            return pdf_content, report_type
+
+        return merged, report_type
+
+    def _collect_seiq_datasheets(self, res_ids):
+        """Devuelve, en orden de aparición en las líneas, el contenido binario
+        (bytes) de la ficha técnica de cada producto de las órdenes que tenga
+        una cargada. Un producto repetido se incluye una sola vez.
+        """
+        orders = self.env["sale.order"].browse(res_ids)
+        Attachment = self.env["ir.attachment"].sudo()
+
+        ficha_pdfs = []
+        seen_templates = set()
+        for order in orders:
+            for line in order.order_line:
+                product = line.product_id
+                if not product:
+                    continue
+                template = product.product_tmpl_id
+                if template.id in seen_templates:
+                    continue
+                seen_templates.add(template.id)
+
+                attachment = Attachment.search(
+                    [
+                        ("res_model", "=", "product.template"),
+                        ("res_id", "=", template.id),
+                        ("mimetype", "=", "application/pdf"),
+                        ("name", "ilike", "ficha"),
+                    ],
+                    order="id desc",
+                    limit=1,
+                )
+                if not attachment:
+                    continue
+
+                content = self._fetch_attachment_pdf(attachment)
+                if content:
+                    ficha_pdfs.append(content)
+
+        return ficha_pdfs
+
+    def _fetch_attachment_pdf(self, attachment):
+        """Obtiene los bytes del PDF de un adjunto.
+
+        - Adjunto tipo URL (fichas SEIQ alojadas en seiqgroupsa.com.ar): se
+          descarga siempre al vuelo para reflejar la versión vigente de la
+          ficha (SEIQ publica versiones nuevas del PDF).
+        - Adjunto binario: se usa el contenido almacenado en Odoo.
+
+        Devuelve ``None`` (y loguea) si no se pudo obtener.
+        """
+        if attachment.type == "url":
+            return self._fetch_pdf_from_url(attachment)
+
+        if attachment.datas:
+            try:
+                return base64.b64decode(attachment.datas)
+            except Exception:  # noqa: BLE001
+                _logger.warning(
+                    "cristal_ficha_tecnica: no se pudo decodificar la ficha "
+                    "binaria '%s' (id %s).",
+                    attachment.name,
+                    attachment.id,
+                )
+        return None
+
+    def _fetch_pdf_from_url(self, attachment):
+        url = attachment.url
+        if not url:
+            return None
+        try:
+            response = requests.get(
+                url,
+                timeout=_FETCH_TIMEOUT,
+                headers={"User-Agent": "Mozilla/5.0 (OdooReport)"},
+            )
+            response.raise_for_status()
+        except Exception:  # noqa: BLE001
+            _logger.warning(
+                "cristal_ficha_tecnica: no se pudo descargar la ficha '%s' "
+                "desde %s.",
+                attachment.name,
+                url,
+            )
+            return None
+
+        content = response.content
+        # Validación mínima: que el contenido descargado sea realmente un PDF
+        # (evita mergear una página de error HTML).
+        if not content or not content[:5].startswith(b"%PDF"):
+            _logger.warning(
+                "cristal_ficha_tecnica: el contenido de '%s' (%s) no es un PDF "
+                "válido; se omite.",
+                attachment.name,
+                url,
+            )
+            return None
+
+        return content

--- a/cristal_ficha_tecnica/report/sale_report_ficha.xml
+++ b/cristal_ficha_tecnica/report/sale_report_ficha.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!--
+        Template idéntico al presupuesto estándar de venta
+        (reutiliza sale.report_saleorder_document). El adjuntado de las fichas
+        técnicas se hace en Python, en ir.actions.report._render_qweb_pdf.
+    -->
+    <template id="report_saleorder_ficha">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="doc">
+                <t t-call="sale.report_saleorder_document" t-lang="doc.partner_id.lang"/>
+            </t>
+        </t>
+    </template>
+
+    <!-- Reporte adicional disponible en el menú Imprimir de la orden de venta. -->
+    <record id="action_report_saleorder_ficha" model="ir.actions.report">
+        <field name="name">Cotización + Ficha Técnica</field>
+        <field name="model">sale.order</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">cristal_ficha_tecnica.report_saleorder_ficha</field>
+        <field name="report_file">cristal_ficha_tecnica.report_saleorder_ficha</field>
+        <field name="print_report_name">(object.state in ('draft', 'sent') and 'Cotizacion FT - %s' % (object.name) or 'Pedido FT - %s' % (object.name))</field>
+        <field name="binding_model_id" ref="sale.model_sale_order"/>
+        <field name="binding_type">report</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Qué agrega

Módulo **cristal_ficha_tecnica** (Odoo 18). Suma un segundo reporte en las órdenes de venta: **"Cotización + Ficha Técnica"** (aparece en el menú Imprimir junto a "Presupuesto").

Genera el **mismo PDF** que el presupuesto estándar y, a continuación, adjunta la **ficha técnica (PDF)** de cada producto de la orden que la tenga cargada como adjunto.

## Cómo funciona

- El template reutiliza `sale.report_saleorder_document` → el PDF de la cotización es **idéntico** al estándar.
- Override de `ir.actions.report._render_qweb_pdf`: por cada producto de la orden (dedup por template, en orden de líneas) busca en `product.template` un `ir.attachment` PDF cuyo nombre contenga **"ficha"** (así discrimina de catálogos y certificados SENASA que también cuelgan del producto).
- Las fichas SEIQ están cargadas como **adjunto tipo URL** (`seiqgroupsa.com.ar`) → se **descargan al vuelo** con `requests`. SEIQ versiona los PDF (ej. `FICHA-TECNICA-ACID_NUEVA.pdf`), por eso **no se cachea**: siempre baja la vigente. Los adjuntos binarios usan el contenido almacenado.
- Merge con `odoo.tools.pdf.merge_pdf`. Valida `%PDF` y **degrada a la cotización sola** ante cualquier fallo (sitio caído, URL rota, sin fichas) sin romper la impresión.

## Datos

- 29 productos SEIQ (ids 15836–15872) tienen ficha cargada.
- `depends: ["sale"]`, `auto_install: True` → se instala solo en el build de Odoo.sh.

## Cómo probar

Abrir una cotización con productos SEIQ → **Imprimir → Cotización + Ficha Técnica** → el PDF sale con la cotización seguida de las fichas de cada producto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
